### PR TITLE
Bugfix barclicked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.DS_Store
 *.codekit

--- a/jquery.range.js
+++ b/jquery.range.js
@@ -139,8 +139,19 @@
 			if (this.isSingle())
 				this.setPosition(this.pointers.last(), x, true, true);
 			else {
-				var pointer = Math.abs(parseInt(this.pointers.first().css('left'), 10) - x + this.pointers.first().width() / 2) < Math.abs(parseInt(this.pointers.last().css('left'), 10) - x + this.pointers.first().width() / 2) ?
-					this.pointers.first() : this.pointers.last();
+				var firstLeft      	= parseInt(this.pointers.first().css('left'), 10),
+						firstHalfWidth 	= this.pointers.first().width() / 2,
+						lastLeft 			 	= parseInt(this.pointers.last().css('left'), 10),
+						lastHalfWidth  	= this.pointers.first().width() / 2,
+						leftSide        = Math.abs(firstLeft - x + firstHalfWidth),
+						rightSide       = Math.abs(lastLeft - x + lastHalfWidth),
+						pointer;
+
+				if(leftSide == rightSide) {
+					pointer = x < firstLeft ? this.pointers.first() : this.pointers.last();
+				} else {
+					pointer = leftSide < rightSide ? this.pointers.first() : this.pointers.last();
+				}
 				this.setPosition(pointer, x, true, true);
 			}
 		},


### PR DESCRIPTION
Fixes bug where a range input could get its pointers turned around. To reproduce the error:

- Go to jRange demo page: http://nitinhayaran.github.io/jRange/demo/
- In the second range input (25% to 75%), make both pointers meet at 75%
- Click the bar anywhere left of the pointers: the last pointer will move, resulting in turned around pointers.

The pushed fix is overly verbose for the sake of clarity.