### PR TITLE
adding fitBounds functionality

### DIFF
--- a/jquery.range.js
+++ b/jquery.range.js
@@ -34,7 +34,8 @@
 			format: '%s',
 			theme: 'theme-green',
 			width: 300,
-			disable: false
+			disable: false,
+			fitBounds:false
 		},
 		template: '<div class="slider-container">\
 			<div class="back-bar">\
@@ -232,7 +233,9 @@
 
 			var width = label.html(text).width(),
 				left = position - width / 2;
-			left = Math.min(Math.max(left, 0), this.options.width - width);
+			if(this.fitBounds){
+				left = Math.min(Math.max(left, 0), this.options.width - width);
+			}
 			label[animate ? 'animate' : 'css']({
 				left: left
 			});


### PR DESCRIPTION
I've added the fitBounds property, so you can choose whether the label should fit in the parent container or not. There is an issue, when you style the label e.g. add some paddings inside, then while sliding to the 0 value the label would stop earlier, when it's left side will reach the left side of the parent container, sometimes it's not necessary