### PR TITLE
onbarclicked event not being fired in single mode

### DIFF
--- a/jquery.range.js
+++ b/jquery.range.js
@@ -159,8 +159,8 @@
 					pointer = leftSide < rightSide ? this.pointers.first() : this.pointers.last();
 				}
 				this.setPosition(pointer, x, true, true);
-		    this.options.onbarclicked.call(this, this.options.value);
 			}
+			this.options.onbarclicked.call(this, this.options.value);
 		},
 		onChange: function(e, self, pointer, position) {
 			var min, max;


### PR DESCRIPTION
I guess I gave it a try to fix it myself :)

The event is being fired only when the mode is not single.

Steps:

* Create a new instance:
```javascript
$('.js-jrange-input').jRange({
from: "1",
                to: "4",
                step: "0.1",
                scale: ["1","2","3","4"],
                showLabels: false,
                width: 700,
                snap: true,
                value: 4,
                isRange: false,
                onbarclicked: function () {
console.log('this is never called')
                },
                onstatechange: function () {
console.log('this is fine')
                },
                ondragend: function () {
console.log('this is fine')
                }
});
```
* Click on the bar
* the 'onbarclicked' function is not being called