### PR TITLE
Update jquery.range.js

### DIFF
--- a/jquery.range.js
+++ b/jquery.range.js
@@ -293,6 +293,7 @@
 		},
 		isDecimal: function() {
 			return ((this.options.value + this.options.from + this.options.to).indexOf(".")===-1) ? false : true;
+			return ((this.options.value + this.options.from + this.options.to).toString().indexOf(".")===-1) ? false : true;
 		},
 		positionToValue: function(pos) {
 			var value = (pos / this.domNode.width()) * this.interval;


### PR DESCRIPTION
=line 295 changes (function 'isDecimal')=

Here is the current code, concatenation works in numeric mode, resulting object is a number and calling indexOf function fails...

`return ((this.options.value + this.options.from + this.options.to).indexOf(".")===-1) ? false : true;`

How to fix: simply convert resulting object to string, using toString function

`return ((this.options.value + this.options.from + this.options.to).toString().indexOf(".")===-1) ? false : true;`

This bug causes unpredicted behaviour. 

**Example**. I tried to use 2 sliders at one page. Each slider has range 0..100 (to set the percentage). If I change one slider to 35%, second slider must be changed dynamically to 65%. So, to implement this functionality I use 'onstatechange' plus 'setValue' methods.  But when I set value of second slider from 'onstatechange' event of first slider, it doesn't change the label of second slider. This is the first issue. Second issue is: when I try to change the value of second slider by dragging it, it doesn't change first slider. After digging in code, I've found the reason - simply because it couldn't call indexOf function (bug described above). I attach the example in ZIP, see 'index.html' file. I included also my fix, see 'jquery.range.fix.js' (so you can quickly test that it works).

[BugExample and fix, zip archive](https://github.com/nitinhayaran/jRange/files/510582/BugExample.zip)
